### PR TITLE
Issue/45-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest --run --reporter verbose --globals",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@octokit/rest": "^20.0.2",

--- a/src/__test__/copy.spec.tsx
+++ b/src/__test__/copy.spec.tsx
@@ -1,4 +1,4 @@
-import { getByText, render, screen } from "@testing-library/react";
+import { getByText, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import App from "../App";
@@ -18,7 +18,7 @@ describe("클립보드 복사 테스트", () => {
     const clipboardText = await navigator.clipboard.readText();
     const generatedText = generateDrawClipboardMsg(drawList);
 
-    expect(clipboardText).toEqual(generatedText);
+    await waitFor(() => expect(clipboardText).toEqual(generatedText));
   });
 
   test("단건 복사 테스트", async () => {
@@ -36,6 +36,6 @@ describe("클립보드 복사 테스트", () => {
     const clipboardText = await navigator.clipboard.readText();
     const generatedText = generateDrawClipboardMsg(drawList[0]);
 
-    expect(clipboardText).toEqual(generatedText);
+    await waitFor(() => expect(clipboardText).toEqual(generatedText));
   });
 });

--- a/src/__test__/draw.spec.tsx
+++ b/src/__test__/draw.spec.tsx
@@ -1,4 +1,4 @@
-import { getByText, render, screen } from "@testing-library/react";
+import { getByText, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import _intersection from "lodash/intersection";
 
@@ -19,7 +19,7 @@ describe("번호 뽑기 테스트", () => {
       return acc && isAllDifferentNumbers;
     }, true);
 
-    expect(allSetDrawn).toBe(true);
+    await waitFor(() => expect(allSetDrawn).toBe(true));
   });
 
   test("1회 뽑기 테스트", async () => {
@@ -33,6 +33,6 @@ describe("번호 뽑기 테스트", () => {
 
     const isDrawn = _intersection(beforeDraw[0], afterDraw[0]).length === 0;
 
-    expect(isDrawn).toBe(true);
+    await waitFor(() => expect(isDrawn).toBe(true));
   });
 });

--- a/src/__test__/saved.spec.tsx
+++ b/src/__test__/saved.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import App from "../App";
@@ -11,7 +11,7 @@ describe("보관함 테스트", () => {
     await userEvent.click(await screen.findByText("5회 뽑기"));
     await userEvent.click(await screen.findByText("보관하기"));
 
-    expect(await db.savedDraws.count()).toBe(1);
+    await waitFor(async () => expect(await db.savedDraws.count()).toBe(1));
   });
 
   test("보관함 삭제 테스트", async () => {
@@ -26,6 +26,6 @@ describe("보관함 테스트", () => {
     await userEvent.click(await screen.findByText("보관함"));
     await userEvent.click(await screen.findByText("삭제"));
 
-    expect(await db.savedDraws.count()).toBe(0);
+    await waitFor(async () => expect(await db.savedDraws.count()).toBe(0));
   });
 });


### PR DESCRIPTION
#45 

테스트를 실행할 때 React 상태 업데이트가 완료되기 전에 테스트 함수가 종료되어 발생하는 warning 해결을 위해 expect 실행을 `waitFor` 함수로 감싸 해결.

ref: https://coffeeandcakeandnewjeong.tistory.com/65