### PR TITLE
클립보드 복사 대신 Web Share API 적용

### DIFF
--- a/src/assets/share.svg
+++ b/src/assets/share.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+  <path fill-rule="evenodd" d="M15.75 4.5a3 3 0 1 1 .825 2.066l-8.421 4.679a3.002 3.002 0 0 1 0 1.51l8.421 4.679a3 3 0 1 1-.729 1.31l-8.421-4.678a3 3 0 1 1 0-4.132l8.421-4.679a3 3 0 0 1-.096-.755Z" clip-rule="evenodd" />
+</svg>

--- a/src/components/DrawActions/index.tsx
+++ b/src/components/DrawActions/index.tsx
@@ -5,12 +5,13 @@ import ButtonGroup from "@/components/ButtonGroup";
 import Dropdown from "@/components/Dropdown";
 import ManualSelectModal from "@/components/Modal/ManualSelectModal";
 import { useToast } from "@/hooks";
-import { copyDrawList, drawNumbers, isDrawEmpty } from "@/utils";
+import { shareDrawList, drawNumbers, isDrawEmpty, isWebShareSupported } from "@/utils";
 import { useDrawStore } from "@/store";
 import { overlay } from "overlay-kit";
 import { DrawListItem } from "@/types";
 
 import TicketIcon from "@/assets/ticket.svg?react";
+import ShareIcon from "@/assets/share.svg?react";
 import ClipboardIcon from "@/assets/clipboard-document.svg?react";
 import ClipboardCheckIcon from "@/assets/clipboard-document-check.svg?react";
 import CheckCircleIcon from "@/assets/check-circle.svg?react";
@@ -27,14 +28,14 @@ export default function DrawActions({ index }: DrawActionsProps) {
   const [copied, setCopied] = useState(false);
   const { showToast } = useToast();
 
-  const handleCopy = () => {
-    copyDrawList(currentItem, () => {
+  const handleShare = () => {
+    shareDrawList(currentItem, (type) => {
       setCopied(true);
       setTimeout(() => {
         setCopied(false);
       }, 2000);
       showToast({
-        content: "클립보드에 복사되었습니다.",
+        content: type === "share" ? "공유 화면이 열립니다." : "클립보드에 복사되었습니다.",
         icon: (
           <CheckCircleIcon className={cx("text-green-500", "w-6", "h-6")} />
         ),
@@ -74,9 +75,13 @@ export default function DrawActions({ index }: DrawActionsProps) {
               disabled: isDrawEmpty(currentItem),
             },
             {
-              icon: <ClipboardIcon className={cx("w-5", "h-5")} />,
-              text: "복사",
-              onClick: handleCopy,
+              icon: isWebShareSupported ? (
+                <ShareIcon className={cx("w-5", "h-5")} />
+              ) : (
+                <ClipboardIcon className={cx("w-5", "h-5")} />
+              ),
+              text: isWebShareSupported ? "공유" : "복사",
+              onClick: handleShare,
               disabled: isDrawEmpty(currentItem),
             },
             {
@@ -98,10 +103,16 @@ export default function DrawActions({ index }: DrawActionsProps) {
               disabled: isDrawEmpty(currentItem),
             },
             {
-              icon: copied ? <ClipboardCheckIcon /> : <ClipboardIcon />,
-              text: `복사${copied ? "됨" : ""} `,
-              onClick: handleCopy,
-              disabled: isDrawEmpty(currentItem) || copied,
+              icon: isWebShareSupported ? (
+                <ShareIcon />
+              ) : copied ? (
+                <ClipboardCheckIcon />
+              ) : (
+                <ClipboardIcon />
+              ),
+              text: isWebShareSupported ? "공유" : `복사${copied ? "됨" : ""} `,
+              onClick: handleShare,
+              disabled: isDrawEmpty(currentItem) || (!isWebShareSupported && copied),
             },
             {
               icon: <WindowIcon />,

--- a/src/components/DrawSection/index.tsx
+++ b/src/components/DrawSection/index.tsx
@@ -6,11 +6,12 @@ import Button from "@/components/Button";
 import { db } from "@/db/savedDraw";
 import { useWinningHistory } from "@/hooks/winningHistory";
 import { useToast } from "@/hooks";
-import { copyDrawList, drawAllNumbers, isDrawEmpty } from "@/utils";
+import { shareDrawList, drawAllNumbers, isDrawEmpty, isWebShareSupported } from "@/utils";
 import { useDrawStore } from "@/store";
 import { DrawList, DrawListItem } from "@/types";
 
 import TicketIcon from "@/assets/ticket.svg?react";
+import ShareIcon from "@/assets/share.svg?react";
 import ClipboardIcon from "@/assets/clipboard-document.svg?react";
 import ClipboardCheckIcon from "@/assets/clipboard-document-check.svg?react";
 import InboxIcon from "@/assets/inbox-arrow-down.svg?react";
@@ -23,14 +24,14 @@ export default function DrawSection() {
   const { round: recentRound } = useWinningHistory();
   const { showToast } = useToast();
 
-  const handleCopy = () => {
-    copyDrawList(drawList, () => {
+  const handleShare = () => {
+    shareDrawList(drawList, (type) => {
       setCopied(true);
       setTimeout(() => {
         setCopied(false);
       }, 2000);
       showToast({
-        content: "클립보드에 복사되었습니다.",
+        content: type === "share" ? "공유 화면이 열립니다." : "클립보드에 복사되었습니다.",
         icon: (
           <CheckCircleIcon className={cx("text-green-500", "w-6", "h-6")} />
         ),
@@ -91,7 +92,11 @@ export default function DrawSection() {
       <div className={cx("flex", "gap-2")}>
         <Button
           icon={
-            copied ? (
+            isWebShareSupported ? (
+              <ShareIcon
+                className={cx("w-6", "h-6", "max-sm:w-5", "max-sm:h-5")}
+              />
+            ) : copied ? (
               <ClipboardCheckIcon
                 className={cx("w-6", "h-6", "max-sm:w-5", "max-sm:h-5")}
               />
@@ -101,10 +106,10 @@ export default function DrawSection() {
               />
             )
           }
-          onClick={handleCopy}
-          disabled={isDrawEmpty(drawList) || copied}
+          onClick={handleShare}
+          disabled={isDrawEmpty(drawList) || (!isWebShareSupported && copied)}
         >
-          {copied ? "복사됨" : "전체복사"}
+          {isWebShareSupported ? "전체 공유" : copied ? "복사됨" : "전체복사"}
         </Button>
         <Button
           icon={

--- a/src/components/SavedActions/index.tsx
+++ b/src/components/SavedActions/index.tsx
@@ -5,10 +5,11 @@ import { useToast } from "@/hooks";
 import Dropdown from "@/components/Dropdown";
 import ButtonGroup from "@/components/ButtonGroup";
 import { SavedDraw, db } from "@/db/savedDraw";
-import { copyDrawList } from "@/utils";
+import { shareDrawList, isWebShareSupported } from "@/utils";
 import ConfirmModal from "@/components/Modal/ConfirmModal";
 import { overlay } from "overlay-kit";
 
+import ShareIcon from "@/assets/share.svg?react";
 import ClipboardIcon from "@/assets/clipboard-document.svg?react";
 import ClipboardCheckIcon from "@/assets/clipboard-document-check.svg?react";
 import TrashIcon from "@/assets/trash.svg?react";
@@ -23,14 +24,14 @@ export default function SavedActions({ data }: SavedActionsProps) {
   const [copied, setCopied] = useState(false);
   const { showToast } = useToast();
 
-  const copyToClipboard = () => {
-    copyDrawList(draws, () => {
+  const handleShare = () => {
+    shareDrawList(draws, (type) => {
       setCopied(true);
       setTimeout(() => {
         setCopied(false);
       }, 2000);
       showToast({
-        content: "클립보드에 복사되었습니다.",
+        content: type === "share" ? "공유 화면이 열립니다." : "클립보드에 복사되었습니다.",
         icon: (
           <CheckCircleIcon className={cx("text-green-500", "w-6", "h-6")} />
         ),
@@ -66,10 +67,14 @@ export default function SavedActions({ data }: SavedActionsProps) {
         <Dropdown
           items={[
             {
-              icon: <ClipboardIcon className={cx("w-5", "h-5")} />,
-              text: "복사",
-              onClick: copyToClipboard,
-              disabled: copied,
+              icon: isWebShareSupported ? (
+                <ShareIcon className={cx("w-5", "h-5")} />
+              ) : (
+                <ClipboardIcon className={cx("w-5", "h-5")} />
+              ),
+              text: isWebShareSupported ? "공유" : "복사",
+              onClick: handleShare,
+              disabled: !isWebShareSupported && copied,
             },
             {
               icon: <TrashIcon className={cx("w-5", "h-5")} />,
@@ -83,10 +88,16 @@ export default function SavedActions({ data }: SavedActionsProps) {
         <ButtonGroup
           items={[
             {
-              icon: copied ? <ClipboardCheckIcon /> : <ClipboardIcon />,
-              text: `복사${copied ? "됨" : ""} `,
-              onClick: copyToClipboard,
-              disabled: copied,
+              icon: isWebShareSupported ? (
+                <ShareIcon />
+              ) : copied ? (
+                <ClipboardCheckIcon />
+              ) : (
+                <ClipboardIcon />
+              ),
+              text: isWebShareSupported ? "공유" : `복사${copied ? "됨" : ""} `,
+              onClick: handleShare,
+              disabled: !isWebShareSupported && copied,
             },
             {
               icon: <TrashIcon />,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -49,17 +49,31 @@ export function generateDrawClipboardMsg(numbers: DrawList | DrawListItem) {
   return numbersToText;
 }
 
-export async function copyDrawList(
+export const isWebShareSupported = typeof navigator !== "undefined" && !!navigator.share;
+
+export async function shareDrawList(
   numbers: DrawList | DrawListItem,
-  onCopy?: () => void
+  onSuccess?: (type: "share" | "copy") => void
 ) {
-  const clipboardMessage = generateDrawClipboardMsg(numbers);
-  try {
-    await navigator.clipboard.writeText(clipboardMessage);
-  } catch (e) {
-    console.error(e);
-  } finally {
-    onCopy?.();
+  const textMessage = generateDrawClipboardMsg(numbers);
+  if (isWebShareSupported) {
+    try {
+      await navigator.share({
+        text: textMessage,
+      });
+      onSuccess?.("share");
+    } catch (e) {
+      if ((e as Error).name !== "AbortError") {
+        console.error("Error sharing:", e);
+      }
+    }
+  } else {
+    try {
+      await navigator.clipboard.writeText(textMessage);
+      onSuccess?.("copy");
+    } catch (e) {
+      console.error(e);
+    }
   }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,6 @@ import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { VitePWA } from "vite-plugin-pwa";
-
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [


### PR DESCRIPTION
- Web Share API 지원 환경에서 네이티브 공유 다이얼로그 호출
- 미지원 환경(데스크톱 등)의 경우 기존 클립보드 복사 방식(Fallback) 유지
- 공유 아이콘(`share.svg`) 추가 및 기존 복사 아이콘들 교체
- `copy.spec.tsx` 유닛 테스트 업데이트
- Resolves #16