### PR TITLE
🧹 [Code Health] Refactor calculateRank helper for better maintainability

### DIFF
--- a/src/utils/rank.ts
+++ b/src/utils/rank.ts
@@ -17,6 +17,21 @@ export function getIntersectedNumbers(
   }
 }
 
+export function calculateRank(intersectedLength: number, hasBonus: boolean): number {
+  switch (intersectedLength) {
+    case 6:
+      return hasBonus ? 2 : 1;
+    case 5:
+      return 3;
+    case 4:
+      return 4;
+    case 3:
+      return 5;
+    default:
+      return -1;
+  }
+}
+
 export function getHighestRankByDrawsDiff(
   draws: DrawList,
   won: DrawListItem,
@@ -26,18 +41,7 @@ export function getHighestRankByDrawsDiff(
     .map((draw) => {
       const intersected = getIntersectedNumbers(draw, won, bonus);
       const hasBonus = intersected.includes(bonus);
-      switch (intersected.length) {
-        case 6:
-          return hasBonus ? 2 : 1;
-        case 5:
-          return 3;
-        case 4:
-          return 4;
-        case 3:
-          return 5;
-        default:
-          return -1;
-      }
+      return calculateRank(intersected.length, hasBonus);
     })
     .filter((rank) => rank > 0);
   return ranks.length > 0 ? Math.min(...ranks) : -1;
@@ -51,18 +55,7 @@ export function getRanksByDraw(
   return draws.map((draw) => {
     const intersected = getIntersectedNumbers(draw, won, bonus);
     const hasBonus = intersected.includes(bonus);
-    switch (intersected.length) {
-      case 6:
-        return hasBonus ? 2 : 1;
-      case 5:
-        return 3;
-      case 4:
-        return 4;
-      case 3:
-        return 5;
-      default:
-        return -1;
-    }
+    return calculateRank(intersected.length, hasBonus);
   });
 }
 


### PR DESCRIPTION
🎯 **What:** Extracted duplicated switch statement from `getHighestRankByDrawsDiff` and `getRanksByDraw` in `src/utils/rank.ts` into a helper function `calculateRank`.

💡 **Why:** Reduces code duplication and improves code maintainability.

✅ **Verification:** Verified by successfully running test suite (`npm run test`) and confirming all tests pass.

✨ **Result:** The code for determining the rank based on intersections and bonus number is cleaner and DRY (Don't Repeat Yourself).

---
*PR created automatically by Jules for task [16201248752584002564](https://jules.google.com/task/16201248752584002564) started by @anthonyminyungi*