### PR TITLE
🔒 fix: missing rel="noopener noreferrer" on external link

### DIFF
--- a/src/components/InfoLink/index.tsx
+++ b/src/components/InfoLink/index.tsx
@@ -5,6 +5,7 @@ export default function InfoLink() {
     <a
       href="https://anthonymin.notion.site/Rantto-dbd4aa3776d9456885cdf06b06bf5da0"
       target="_blank"
+      rel="noopener noreferrer"
       className="flex w-fit items-center gap-1 rounded-md px-2 py-1 font-semibold text-blue-600 hover:bg-gray-100 dark:text-blue-400 dark:hover:bg-neutral-800"
     >
       <InfoCircle />


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the absence of `rel="noopener noreferrer"` on an external link pointing to a Notion site with `target="_blank"`.
⚠️ **Risk:** The potential impact if left unfixed is reverse tabnabbing, a security risk where the newly opened tab could maliciously hijack the original page via the `window.opener` object.
🛡️ **Solution:** The fix adds the `rel="noopener noreferrer"` attribute to the anchor tag to prevent the new page from accessing the `window.opener` property, mitigating the vulnerability.

---
*PR created automatically by Jules for task [15381572756730933472](https://jules.google.com/task/15381572756730933472) started by @anthonyminyungi*