### PR TITLE
🧹 [code health] Add variant to ToastItem interface

### DIFF
--- a/src/components/ToastItem/index.tsx
+++ b/src/components/ToastItem/index.tsx
@@ -5,10 +5,11 @@ import { useToast } from "@/hooks";
 
 import CloseIcon from "@/assets/x-mark.svg?react";
 
-export default function ToastListItem({ id, icon, content }: ToastItem) {
+export default function ToastListItem({ id, icon, content, variant = "default" }: ToastItem) {
   const { closeToast } = useToast();
   return (
     <div
+      data-variant={variant}
       className={cx(
         "mt-2 max-w-full rounded-lg px-3 py-3 font-semibold transition-colors",
         "bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,10 +31,12 @@ export interface WinningHistory {
   createdAt: string;
 }
 
+export type ToastVariant = "default" | "success" | "error" | "warning" | "info";
+
 export interface ToastItem {
   id?: string;
   content: string;
   duration?: number;
   icon?: ReactNode;
-  // TODO: variant 추가
+  variant?: ToastVariant;
 }


### PR DESCRIPTION
🎯 **What:** Added an optional `variant` string literal union to the `ToastItem` interface, resolving the actionable `// TODO: variant 추가` comment in `src/types/index.ts`. Also updated the `ToastListItem` component to accept and consume the `variant` prop as a `data-variant` attribute.
💡 **Why:** This makes the codebase more robust by formally supporting toast variations (like success, error, warning) at the type level. The component change paves the way for style adjustments based on variants while remaining completely backwards-compatible since it defaults to `"default"`.
✅ **Verification:** Verified that `pnpm run test` still passes successfully, ensuring this purely additive structural change does not break existing application behavior. `pnpm run lint` and `pnpm run build` also completed without errors.
✨ **Result:** Improved maintainability by cleaning up a lingering TODO and laying the structural foundation for more sophisticated toast feedback mechanisms.

---
*PR created automatically by Jules for task [16532579081625605823](https://jules.google.com/task/16532579081625605823) started by @anthonyminyungi*