### PR TITLE
🧪 Add unit tests for useToast hook

### DIFF
--- a/src/components/ToastItem/index.tsx
+++ b/src/components/ToastItem/index.tsx
@@ -5,7 +5,12 @@ import { useToast } from "@/hooks";
 
 import CloseIcon from "@/assets/x-mark.svg?react";
 
-export default function ToastListItem({ id, icon, content, variant = "default" }: ToastItem) {
+export default function ToastListItem({
+  id,
+  icon,
+  content,
+  variant = "default",
+}: ToastItem) {
   const { closeToast } = useToast();
   return (
     <div

--- a/src/hooks/index.spec.ts
+++ b/src/hooks/index.spec.ts
@@ -1,0 +1,79 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi, Mock } from "vitest";
+
+import { useToastStore } from "@/store";
+import { useToast } from "./index";
+
+vi.mock("@/store", () => ({
+  useToastStore: vi.fn(),
+}));
+
+describe("useToast", () => {
+  let addToastMock: Mock;
+  let removeToastMock: Mock;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    addToastMock = vi.fn();
+    removeToastMock = vi.fn();
+
+    (useToastStore as unknown as Mock).mockReturnValue({
+      addToast: addToastMock,
+      removeToast: removeToastMock,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.resetAllMocks();
+  });
+
+  it("should call addToast and then removeToast after default duration (3000ms)", () => {
+    const { result } = renderHook(() => useToast());
+
+    result.current.showToast({ content: "Test Toast" });
+
+    expect(addToastMock).toHaveBeenCalledTimes(1);
+    expect(addToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "Test Toast", id: expect.any(String) })
+    );
+
+    const toastId = addToastMock.mock.calls[0][0].id;
+
+    expect(removeToastMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2999);
+    expect(removeToastMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(removeToastMock).toHaveBeenCalledTimes(1);
+    expect(removeToastMock).toHaveBeenCalledWith(toastId);
+  });
+
+  it("should call addToast and then removeToast after custom duration", () => {
+    const { result } = renderHook(() => useToast());
+
+    result.current.showToast({ content: "Custom Toast", duration: 5000 });
+
+    expect(addToastMock).toHaveBeenCalledTimes(1);
+    const toastId = addToastMock.mock.calls[0][0].id;
+
+    vi.advanceTimersByTime(3000);
+    expect(removeToastMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2000);
+    expect(removeToastMock).toHaveBeenCalledTimes(1);
+    expect(removeToastMock).toHaveBeenCalledWith(toastId);
+  });
+
+  it("should allow manually closing a toast", () => {
+    const { result } = renderHook(() => useToast());
+
+    result.current.closeToast("manual-id");
+
+    expect(removeToastMock).toHaveBeenCalledTimes(1);
+    expect(removeToastMock).toHaveBeenCalledWith("manual-id");
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -29,9 +29,10 @@ export const useToast = () => {
   };
 
   const showToast = (toastItem: ToastItem) => {
-    const id = typeof crypto !== "undefined" && crypto.randomUUID
-      ? crypto.randomUUID()
-      : Math.random().toString(36).substring(2);
+    const id =
+      typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : Math.random().toString(36).substring(2);
     addToast({ ...toastItem, id });
     setTimeout(() => removeToast(id), toastItem.duration ?? 3000);
   };

--- a/src/utils/rank.ts
+++ b/src/utils/rank.ts
@@ -17,7 +17,10 @@ export function getIntersectedNumbers(
   }
 }
 
-export function calculateRank(intersectedLength: number, hasBonus: boolean): number {
+export function calculateRank(
+  intersectedLength: number,
+  hasBonus: boolean
+): number {
   switch (intersectedLength) {
     case 6:
       return hasBonus ? 2 : 1;


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `useToast` hook in `src/hooks/index.ts`.
📊 **Coverage:** Covered all functionality of the `useToast` hook, including:
- Adding a toast with default duration.
- Adding a toast with custom duration.
- Manually closing a toast.
The `useToastStore` zustand state was mocked to strictly isolate testing of the hook and mock timers were used to accurately assert timeout durations safely.
✨ **Result:** Improved overall test coverage for UI state interactions preventing potential regressions when modifying `useToast` or global toast state.

---
*PR created automatically by Jules for task [292220785493192836](https://jules.google.com/task/292220785493192836) started by @anthonyminyungi*